### PR TITLE
drpcconn: Expose termination signal

### DIFF
--- a/drpc.go
+++ b/drpc.go
@@ -34,8 +34,8 @@ type Conn interface {
 	// Close closes the connection.
 	Close() error
 
-	// Closed returns true if the connection is definitely closed.
-	Closed() bool
+	// Closed returns a channel that is closed if the connection is definitely closed.
+	Closed() <-chan struct{}
 
 	// Transport returns the transport the connection is using.
 	Transport() Transport

--- a/drpcconn/README.md
+++ b/drpcconn/README.md
@@ -40,9 +40,9 @@ Close closes the connection.
 #### func (*Conn) Closed
 
 ```go
-func (c *Conn) Closed() bool
+func (c *Conn) Closed() <-chan struct{}
 ```
-Closed returns true if the connection is already closed.
+Closed returns a channel that is closed once the connection is closed.
 
 #### func (*Conn) Invoke
 

--- a/drpcconn/conn.go
+++ b/drpcconn/conn.go
@@ -50,8 +50,8 @@ func (c *Conn) Transport() drpc.Transport {
 	return c.tr
 }
 
-// Closed returns true if the connection is already closed.
-func (c *Conn) Closed() bool {
+// Closed returns a channel that is closed once the connection is closed.
+func (c *Conn) Closed() <-chan struct{} {
 	return c.man.Closed()
 }
 

--- a/drpcmanager/README.md
+++ b/drpcmanager/README.md
@@ -43,9 +43,9 @@ Close closes the transport the manager is using.
 #### func (*Manager) Closed
 
 ```go
-func (m *Manager) Closed() bool
+func (m *Manager) Closed() <-chan struct{}
 ```
-Closed returns if the manager has been closed.
+Closed returns a channel that is closed once the manager is closed
 
 #### func (*Manager) NewClientStream
 

--- a/drpcmanager/manager.go
+++ b/drpcmanager/manager.go
@@ -171,9 +171,9 @@ func (m *Manager) waitForPreviousStream(ctx context.Context) (err error) {
 // exported interface
 //
 
-// Closed returns if the manager has been closed.
-func (m *Manager) Closed() bool {
-	return m.term.IsSet()
+// Closed returns a channel that is closed once the manager is closed.
+func (m *Manager) Closed() <-chan struct{} {
+	return m.term.Signal()
 }
 
 // Close closes the transport the manager is using.


### PR DESCRIPTION
As discussed in #11, this PR exposes the termination signal of a connection, which makes it possible to wait for the connection to be closed.

To work properly, this PR requires #16 to be merged first.

Fixes #11 