### PR TITLE
Golangci lint v1.43.0 changes

### DIFF
--- a/drpcdebug/log_disabled.go
+++ b/drpcdebug/log_disabled.go
@@ -1,6 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
+//go:build !debug
 // +build !debug
 
 package drpcdebug

--- a/drpcserver/util.go
+++ b/drpcserver/util.go
@@ -1,6 +1,7 @@
 // Copyright (C) 2021 Storj Labs, Inc.
 // See LICENSE for copying information.
 
+//go:build !windows
 // +build !windows
 
 package drpcserver


### PR DESCRIPTION
Fixes "File is not `gofmt`-ed with `-s` (gofmt)"

See https://github.com/storj/ci/pull/39