### PR TITLE
drpcwire: expose buffer size on Reader

### DIFF
--- a/drpcmanager/manager.go
+++ b/drpcmanager/manager.go
@@ -27,6 +27,9 @@ type Options struct {
 	// flushing. Normal writes to streams typically issue a flush explicitly.
 	WriterBufferSize int
 
+	// Reader are passed to any readers the manager creates.
+	Reader drpcwire.ReaderOptions
+
 	// Stream are passed to any streams the manager creates.
 	Stream drpcstream.Options
 
@@ -78,7 +81,7 @@ func NewWithOptions(tr drpc.Transport, opts Options) *Manager {
 	m := &Manager{
 		tr:   tr,
 		wr:   drpcwire.NewWriter(tr, opts.WriterBufferSize),
-		rd:   drpcwire.NewReader(tr),
+		rd:   drpcwire.NewReaderWithOptions(tr, opts.Reader),
 		opts: opts,
 
 		pkts:    make(chan drpcwire.Packet),


### PR DESCRIPTION
The maximum was hardcoded at 4MB. This allows it to
be configurable for larger payloads. An option is
exposed in `dprcmanager.Options`.