### PR TITLE
drpcmanager: cancel stream with error when terminated

### DIFF
--- a/drpcmanager/manager.go
+++ b/drpcmanager/manager.go
@@ -291,7 +291,8 @@ func (m *Manager) manageStream(ctx context.Context, stream *drpcstream.Stream) {
 
 	select {
 	case <-m.sigs.term.Signal():
-		stream.Cancel(context.Canceled)
+		err, _ := m.sigs.term.Get()
+		stream.Cancel(err)
 		<-m.sterm
 		return
 


### PR DESCRIPTION
Terminations were canceling streams with `context.Canceled` instead
of surfacing the error, causing unexpected behavior.