### PR TITLE
Fix links to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ A drop-in, lightweight gRPC replacement.
 
  ## Examples
 
-  * [A basic drpc client and server](./tree/main/examples/drpc)
-  * [A basic drpc client and server that also serves a Twirp/grpc-web compatible http server on the same port](./tree/main/examples/drpc)
-  * [Serving gRPC and DRPC on the same port](./tree/main/examples/grpc_and_drpc)
+  * [A basic drpc client and server](../../tree/main/examples/drpc)
+  * [A basic drpc client and server that also serves a Twirp/grpc-web compatible http server on the same port](../../tree/main/examples/drpc)
+  * [Serving gRPC and DRPC on the same port](../../tree/main/examples/grpc_and_drpc)
 
 ## Other Languages
 


### PR DESCRIPTION
The links to the examples were based off "." but in the rendered context that created garbled paths yielding 404s.  

I think this change fixes it.  It looks good in the preview, though unfortunately I wouldn't be 100% sure until it was actually installed.